### PR TITLE
Allow nodes with commas in name

### DIFF
--- a/{{ cookiecutter.repo_name }}/kedro_cli.py
+++ b/{{ cookiecutter.repo_name }}/kedro_cli.py
@@ -216,7 +216,6 @@ def run(
     runner_class = load_obj(runner, "kedro.runner")
 
     tag = _get_values_as_tuple(tag) if tag else tag
-    node_names = _get_values_as_tuple(node_names) if node_names else node_names
 
     context = load_context(Path.cwd(), env=env, extra_params=params)
     context.run(


### PR DESCRIPTION
`kedro run` with filter on `--node` doesn't work on this starter, as the current code splits the parameters by comma.

```
$ kedro run --node preprocessing_companies,preprocessing_shuttles
(...)
2021-01-04 14:31:07,204 - kedro.runner.sequential_runner - INFO - Completed 2 out of 2 tasks
2021-01-04 14:31:07,205 - kedro.runner.sequential_runner - INFO - Pipeline execution completed successfully.

$ kedro run --node 'create_master_table([preprocessed_companies,preprocessed_shuttles,reviews]) -> [master_table]'
(...)
ValueError: Pipeline does not contain nodes named ['reviews]) -> [master_table]', 'create_master_table([preprocessed_companies', 'preprocessed_shuttles'].
```

This fix drops comma-splitting in cli, still allowing to run multiple nodes at once (by multiplicating `--node` param):

```
$ kedro run --node preprocessing_companies --node preprocessing_shuttles
(...)
2021-01-04 14:32:43,665 - kedro.runner.sequential_runner - INFO - Completed 2 out of 2 tasks
2021-01-04 14:32:43,665 - kedro.runner.sequential_runner - INFO - Pipeline execution completed successfully.

$ kedro run --node 'create_master_table([preprocessed_companies,preprocessed_shuttles,reviews]) -> [master_table]'
(...)
2021-01-04 14:33:17,579 - kedro.runner.sequential_runner - INFO - Completed 1 out of 1 tasks
2021-01-04 14:33:17,579 - kedro.runner.sequential_runner - INFO - Pipeline execution completed successfully.
```